### PR TITLE
Issue 2/safety controller node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - |
     docker run --rm \
       -e CONTINUOUS_INTEGRATION=${CONTINUOUS_INTEGRATION} \
-      -e TRAVIS_BRANCH=${TRAVIS_BRANCH} \
+      -e TRAVIS_BRANCH=develop \ # Use the 'develop' GBZ to build for now ${TRAVIS_BRANCH} \
       -v ${TRAVIS_BUILD_DIR}:/root/kuri_edu \
       ${DOCKER_IMAGE}:${TRAVIS_BRANCH} \
       /root/kuri_edu/ci_tools/ci.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,13 @@ before_script:
   - flake8 .
 
 script:
+  # We're forcing TRAVIS_BRANCH=develop below because unlike any of the private repos,
+  # this repo doesn't have a 'develop' integration branch.  A master binary is a bit too
+  # far behind to get this to build, so we're going to force it to use develop bins
   - |
     docker run --rm \
       -e CONTINUOUS_INTEGRATION=${CONTINUOUS_INTEGRATION} \
-      -e TRAVIS_BRANCH=develop \ # Use the 'develop' GBZ to build for now ${TRAVIS_BRANCH} \
+      -e TRAVIS_BRANCH=develop \
       -v ${TRAVIS_BUILD_DIR}:/root/kuri_edu \
       ${DOCKER_IMAGE}:${TRAVIS_BRANCH} \
       /root/kuri_edu/ci_tools/ci.bash

--- a/ci_tools/ci.bash
+++ b/ci_tools/ci.bash
@@ -35,13 +35,19 @@ echo -e "\nRunning Tests"
 set +u  # Ugh. . .
 source ./devel/setup.bash
 set -u
-catkin_make run_tests --source .
+catkin_make run_tests -j1 --source .
 catkin_test_results
 
 echo -e "\nCoverage Report:"
+# Glue together the .coverage files from different locations:
+# If a node generates its own coverage and was run in a ROS test, its numbers
+# will be in ~/.ros/.coverage
+# If code is run in the context of a ROS test with --coverage, its coverage will
+# be in kuri_edu/rostest/.coverage
+coverage combine -a ~/.ros/.coverage
+# coverage combine -a kuri_edu/rostest/.coverage # Nothing using this yet
+
 # Finally, print out some final coverage numbers
-# If ROS tests are added, their coverage files get dropped in the rostest folder
-# combine that with the unit test coverage before generating a report
-# coverage combine -a kuri_edu/rostest/.coverage
 coverage report
+coverage xml   # For upload to a service like codecov.io
 coverage html  # For running locally - makes it easy to see what lines are hit

--- a/kuri_edu/CMakeLists.txt
+++ b/kuri_edu/CMakeLists.txt
@@ -18,6 +18,8 @@ install(DIRECTORY launch
 )
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+
   catkin_add_nosetests(test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
   add_rostest(rostest/test_safety_controller.launch)

--- a/kuri_edu/CMakeLists.txt
+++ b/kuri_edu/CMakeLists.txt
@@ -19,4 +19,6 @@ install(DIRECTORY launch
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+  add_rostest(rostest/test_safety_controller.launch)
 endif()

--- a/kuri_edu/CMakeLists.txt
+++ b/kuri_edu/CMakeLists.txt
@@ -9,6 +9,7 @@ catkin_package()
 
 install(PROGRAMS
   scripts/simple_kuri
+  scripts/safety_controller
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/kuri_edu/launch/safety_controller.launch
+++ b/kuri_edu/launch/safety_controller.launch
@@ -1,0 +1,12 @@
+<!--
+Launches the safety controller node, which is responsible for automatically
+backing kuri away from bumps
+-->
+
+<launch>
+    <node name="safety_controller"
+          pkg="kuri_edu"
+          type="safety_controller"
+          required="true"
+    />
+</launch>

--- a/kuri_edu/launch/safety_controller.launch
+++ b/kuri_edu/launch/safety_controller.launch
@@ -4,9 +4,13 @@ backing kuri away from bumps
 -->
 
 <launch>
+
+    <arg name="cla" default=""/> <!-- Command-line arguments -->
+
     <node name="safety_controller"
           pkg="kuri_edu"
           type="safety_controller"
           required="true"
+          args="$(arg cla)"
     />
 </launch>

--- a/kuri_edu/package.xml
+++ b/kuri_edu/package.xml
@@ -18,4 +18,7 @@
   <run_depend>depth_sensor_driver</run_depend>
   <run_depend>madmux</run_depend>
 
+  <test_depend>rosunit</test_depend>
+  <test_depend>gizmo_gazebo</test_depend>
+
 </package>

--- a/kuri_edu/rostest/test_safety_controller.launch
+++ b/kuri_edu/rostest/test_safety_controller.launch
@@ -1,0 +1,17 @@
+<launch>
+
+    <!-- Start Kuri in a corner facing the wall so we can front-bump--> 
+    <include file="$(find gizmo_gazebo)/launch/gizmo_sim.launch">
+        <arg name="gui" value="true"/>
+    </include>
+
+    <!-- The node that's being tested: -->
+    <include file="$(find kuri_edu)/launch/safety_controller.launch"/>
+
+    <test test-name="test_safety_controller"
+          pkg="kuri_edu"
+          time-limit="300"
+          type="test_safety_controller.py"
+          cwd="node"/>
+
+</launch>

--- a/kuri_edu/rostest/test_safety_controller.launch
+++ b/kuri_edu/rostest/test_safety_controller.launch
@@ -2,11 +2,13 @@
 
     <!-- Start Kuri in a corner facing the wall so we can front-bump--> 
     <include file="$(find gizmo_gazebo)/launch/gizmo_sim.launch">
-        <arg name="gui" value="true"/>
+        <arg name="gui" value="false"/>
     </include>
 
     <!-- The node that's being tested: -->
-    <include file="$(find kuri_edu)/launch/safety_controller.launch"/>
+    <include file="$(find kuri_edu)/launch/safety_controller.launch">
+        <arg name="cla" value="coverage"/>
+    </include>
 
     <test test-name="test_safety_controller"
           pkg="kuri_edu"

--- a/kuri_edu/rostest/test_safety_controller.py
+++ b/kuri_edu/rostest/test_safety_controller.py
@@ -33,8 +33,8 @@ class TestSafetyController(maytest.desktop.RosTestBase):
             gizmo_hw_sim.srv.Kick
         )
 
-        # Wait for the mobile base controller to be onlin before starting
-        mayfield_utils.wait_for_nodes(['controllers'])
+        # Wait for the DUT to be online before starting
+        mayfield_utils.wait_for_nodes(['safety_controller'])
 
     def test_01_kuri_backs_up_when_bumped(self):
         rospy.loginfo("test_01_kuri_backs_up_when_bumped started")
@@ -44,7 +44,7 @@ class TestSafetyController(maytest.desktop.RosTestBase):
         status_mon = SafetyStatusMonitor()
 
         # Test Stimulus
-        self.kick_srv(True, False, True)
+        self.kick_srv(True, False, False)
 
         # Wait for kuri to react
         status_mon.assertSafetyConditionSeen()

--- a/kuri_edu/rostest/test_safety_controller.py
+++ b/kuri_edu/rostest/test_safety_controller.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+import threading
+
+import rostest
+import rospy
+
+import geometry_msgs.msg
+
+import mobile_base
+import mobile_base_driver.msg
+
+import gizmo_hw_sim.srv
+import mayfield_utils
+import maytest.desktop
+
+
+class TestSafetyController(maytest.desktop.RosTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        # For sending drive commands to the safety controller:
+        cls.vel_pub = rospy.Publisher(
+            "/cmd_vel",
+            geometry_msgs.msg.Twist,
+            latch=True,
+            queue_size=2,
+        )
+
+        # For triggering the bump shell:
+        rospy.wait_for_service("/sim_interface/kick")
+        cls.kick_srv = rospy.ServiceProxy(
+            "/sim_interface/kick",
+            gizmo_hw_sim.srv.Kick
+        )
+
+        # Wait for the mobile base controller to be onlin before starting
+        mayfield_utils.wait_for_nodes(['controllers'])
+
+    def test_01_kuri_backs_up_when_bumped(self):
+        rospy.loginfo("test_01_kuri_backs_up_when_bumped started")
+
+        #Establish initial conditions:
+        initial_pos = self.get_gizmo_location()
+        status_mon = SafetyStatusMonitor()
+
+        # Test Stimulus
+        self.kick_srv(True, False, True)
+
+        # Wait for kuri to react
+        status_mon.assertSafetyConditionSeen()
+        status_mon.assertSafetyConditionCleared()
+
+        # Make sure we backed up at least a cm
+        final_pos = self.get_gizmo_location()
+        backup_distance = final_pos[0] - initial_pos[0]
+        self.assertLess(backup_distance, -0.01)
+
+
+class SafetyStatusMonitor(object):
+    '''
+    Monitors the /mobile_base/safety_status topic to tell when bumps are
+    being handled
+    '''
+
+    def __init__(self):
+        self._safety_condition = threading.Event()
+        self._condition_cleared = threading.Event()
+
+        self._sub = rospy.Subscriber(
+            "/mobile_base/safety_status",
+            mobile_base_driver.msg.SafetyStatus,
+            self._safety_status_callback
+        )
+
+    def _safety_status_callback(self, msg):
+        '''
+        Operates in two stages.  If we haven't observed a safety
+        condition yet, sets the safety condition event when we get a non
+        zero safety status.
+
+        If we've observed a safety condition already, sets the condition
+        cleared event when we get a zero safety status
+        '''
+        if not self._safety_condition.is_set():
+            if msg.status != 0:
+                self._safety_condition.set()
+        else:
+            if msg.status == 0:
+                self._condition_cleared.set()
+
+    def assertSafetyConditionSeen(self, timeout=10):
+        assert self._safety_condition.wait(timeout)
+
+    def assertSafetyConditionCleared(self, timeout=10):
+        assert self._condition_cleared.wait(timeout)
+
+
+if __name__ == '__main__':
+    rospy.init_node("test_safety_controller")
+    rostest.rosrun("kuri_edu", "test_safety_controller", TestSafetyController)

--- a/kuri_edu/rostest/test_safety_controller.py
+++ b/kuri_edu/rostest/test_safety_controller.py
@@ -6,7 +6,6 @@ import rospy
 
 import geometry_msgs.msg
 
-import mobile_base
 import mobile_base_driver.msg
 
 import gizmo_hw_sim.srv
@@ -72,7 +71,7 @@ class TestSafetyController(maytest.desktop.RosTestBase):
         self._check_bump_backup([False, False, True])
 
     def _check_bump_backup(self, bumps=[True, True, True]):
-        #Establish initial conditions:
+        # Establish initial conditions:
         initial_pos = self.get_gizmo_location()
         status_mon = SafetyStatusMonitor()
 

--- a/kuri_edu/scripts/safety_controller
+++ b/kuri_edu/scripts/safety_controller
@@ -25,4 +25,3 @@ if __name__ == '__main__':
         safety_controller.shutdown()
         if 'cov' in locals():
             cov.stop()
-            cov.xml_report(ignore_errors=True)

--- a/kuri_edu/scripts/safety_controller
+++ b/kuri_edu/scripts/safety_controller
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import rospy
+
+import kuri_edu
+
+if __name__ == '__main__':
+
+    rospy.init_node('safety_controller')
+
+    safety_controller = kuri_edu.SafetyController()
+
+    try:
+        safety_controller.run()
+    finally:
+        safety_controller.shutdown()

--- a/kuri_edu/scripts/safety_controller
+++ b/kuri_edu/scripts/safety_controller
@@ -1,9 +1,19 @@
 #!/usr/bin/env python
+import sys
+
 import rospy
 
 import kuri_edu
 
 if __name__ == '__main__':
+
+    # If the script was run with 'coverage' we're going to run the python
+    # coverage module to generate line coverage
+    if "coverage" in sys.argv:
+        import coverage
+        cov = coverage.Coverage(auto_data=True)
+        cov.start()
+        reload(kuri_edu.safety_controller)
 
     rospy.init_node('safety_controller')
 
@@ -13,3 +23,6 @@ if __name__ == '__main__':
         safety_controller.run()
     finally:
         safety_controller.shutdown()
+        if 'cov' in locals():
+            cov.stop()
+            cov.xml_report(ignore_errors=True)

--- a/kuri_edu/src/kuri_edu/__init__.py
+++ b/kuri_edu/src/kuri_edu/__init__.py
@@ -1,8 +1,10 @@
 from .battery_monitor import BatteryMonitor
+from .safety_controller import SafetyController
 from .simple_client import SimpleKuriClient
 
 
 __all__ = [
     BatteryMonitor,
+    SafetyController,
     SimpleKuriClient,
 ]

--- a/kuri_edu/src/kuri_edu/safety_controller.py
+++ b/kuri_edu/src/kuri_edu/safety_controller.py
@@ -28,7 +28,7 @@ class SafetyController(object):
         # handle so they'll be ignored by the hardware
         self.UNHANDLED_EVENTS = (
             self._safety_client.safety_statuses()  # All statuses
-            - HANDLED_EVENTS                       # Minus the ones we handle
+            - self.HANDLED_EVENTS                  # Minus the ones we handle
         )
         self._safety_client.safety_override(self.UNHANDLED_EVENTS)
 
@@ -56,7 +56,7 @@ class SafetyController(object):
 
             current_status = self._safety_client.get_safety_status()
 
-            if HANDLED_EVENTS.intersection(current_status) != set():
+            if self.HANDLED_EVENTS.intersection(current_status) != set():
                 with self._sync_lock:
                     self._block_twists = True
 
@@ -68,7 +68,7 @@ class SafetyController(object):
 
                 self._safety_client.safety_override(self.UNHANDLED_EVENTS)
 
-                self._safety_clear(current_status)
+                self._safety_client.safety_clear(current_status)
                 self._block_twists = False
 
             rate.sleep()
@@ -76,7 +76,7 @@ class SafetyController(object):
     def _stop(self):
         self._cmd_vel_pub.publish(
             geometry_msgs.msg.Twist(
-                linear=geometry_msgs.msg.Vector3(0, 0, 0)
+                linear=geometry_msgs.msg.Vector3(0, 0, 0),
                 angular=geometry_msgs.msg.Vector3(0, 0, 0)
             )
         )
@@ -85,7 +85,7 @@ class SafetyController(object):
         for _ in range(self.SAFETY_HZ / 2):
             self._cmd_vel_pub.publish(
                 geometry_msgs.msg.Twist(
-                    linear=geometry_msgs.msg.Vector3(-0.1, 0, 0)
+                    linear=geometry_msgs.msg.Vector3(-0.1, 0, 0),
                     angular=geometry_msgs.msg.Vector3(0, 0, 0)
                 )
             )

--- a/kuri_edu/src/kuri_edu/safety_controller.py
+++ b/kuri_edu/src/kuri_edu/safety_controller.py
@@ -64,7 +64,7 @@ class SafetyController(object):
             mayfield_msgs.msg.NodeStatus("safety_controller", True)
         )
 
-        rate = rospy.Rate(self.SAFETY_HZ) # 10hz by default
+        rate = rospy.Rate(self.SAFETY_HZ)  # 10hz by default
         while not rospy.is_shutdown():
             try:
 

--- a/kuri_edu/src/kuri_edu/safety_controller.py
+++ b/kuri_edu/src/kuri_edu/safety_controller.py
@@ -3,6 +3,7 @@ import threading
 import geometry_msgs.msg
 import rospy
 
+import mayfield_msgs.msg
 import mayfield_utils
 import mobile_base
 
@@ -17,6 +18,13 @@ class SafetyController(object):
     SAFETY_HZ = 10
 
     def __init__(self):
+
+        self._pub = rospy.Publisher(
+            "node_online",
+            mayfield_msgs.msg.NodeStatus,
+            latch=True,
+            queue_size=1,
+        )
 
         # Controllers need to be loaded before we can run
         mayfield_utils.wait_for_nodes(
@@ -50,6 +58,11 @@ class SafetyController(object):
         )
 
     def run(self):
+
+        # Indicate to the world that we're running and ready to go:
+        self._pub.publish(
+            mayfield_msgs.msg.NodeStatus("safety_controller", True)
+        )
 
         rate = rospy.Rate(self.SAFETY_HZ) # 10hz by default
         while not rospy.is_shutdown():

--- a/kuri_edu/src/kuri_edu/safety_controller.py
+++ b/kuri_edu/src/kuri_edu/safety_controller.py
@@ -1,0 +1,107 @@
+import threading
+
+import geometry_msgs.msg
+import rospy
+
+import mayfield_utils
+import mobile_base
+
+
+class SafetyController(object):
+
+    # A set of the safety events we're equipped to handle.
+    # It's just bumpers so we don't need to deal with compexities
+    # like "What happens if a front bump and a rear cliff triggers
+    # at the same time"
+    HANDLED_EVENTS = {'BPR_bp', 'BPM_bp', 'BPL_bp'}
+    SAFETY_HZ = 10
+
+    def __init__(self):
+
+        # Controllers need to be loaded before we can run
+        mayfield_utils.wait_for_nodes(
+            node_names=['controllers'],
+        )
+
+        self._safety_client = mobile_base.SafetyClient()
+        # Override the safety controller for all events that we don't
+        # handle so they'll be ignored by the hardware
+        self.UNHANDLED_EVENTS = (
+            self._safety_client.safety_statuses()  # All statuses
+            - HANDLED_EVENTS                       # Minus the ones we handle
+        )
+        self._safety_client.safety_override(self.UNHANDLED_EVENTS)
+
+        self._sync_lock = threading.Lock()
+        self._block_twists = False
+
+        # Set up publishers before subscribers because once subscribers are
+        # set up, we can start getting callbacks
+        self._cmd_vel_pub = rospy.Publisher(
+            "mobile_base/commands/velocity",
+            geometry_msgs.msg.Twist,
+            queue_size=1
+        )
+
+        self._cmd_vel_sub = rospy.Subscriber(
+            "cmd_vel",
+            geometry_msgs.msg.Twist,
+            self._forward_twists
+        )
+
+    def run(self):
+
+        rate = rospy.Rate(self.SAFETY_HZ) # 10hz by default
+        while not rospy.is_shutdown():
+
+            current_status = self._safety_client.get_safety_status()
+
+            if HANDLED_EVENTS.intersection(current_status) != set():
+                with self._sync_lock:
+                    self._block_twists = True
+
+                # Override the safety status and back the robot up
+                self._stop()  # in case a forward velocity is still enqueued
+                self._safety_client.safety_override(current_status)
+
+                self._back_up(rate)
+
+                self._safety_client.safety_override(self.UNHANDLED_EVENTS)
+
+                self._safety_clear(current_status)
+                self._block_twists = False
+
+            rate.sleep()
+
+    def _stop(self):
+        self._cmd_vel_pub.publish(
+            geometry_msgs.msg.Twist(
+                linear=geometry_msgs.msg.Vector3(0, 0, 0)
+                angular=geometry_msgs.msg.Vector3(0, 0, 0)
+            )
+        )
+
+    def _back_up(self, rate):
+        for _ in range(self.SAFETY_HZ / 2):
+            self._cmd_vel_pub.publish(
+                geometry_msgs.msg.Twist(
+                    linear=geometry_msgs.msg.Vector3(-0.1, 0, 0)
+                    angular=geometry_msgs.msg.Vector3(0, 0, 0)
+                )
+            )
+            rate.sleep()
+        self._stop()
+
+    def shutdown(self):
+        self._safety_client.shutdown()
+
+    def _forward_twists(self, msg):
+        '''
+        This callback listens for twist messages come on standard topics.
+        If we're not handling a safety event, we forward the message on
+        to the wheels.  If we're currently handling a safety event, then
+        we block the message from going to the wheels
+        '''
+        with self._sync_lock:
+            if not self._block_twists:
+                self._cmd_vel_pub.publish(msg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,4 @@ cover-package=kuri_edu
 omit=
     */setup.py
     *kuri_edu/test/*
+    */lib/python2.7/dist-packages/*


### PR DESCRIPTION
Resolves issue #2
We're providing the safety back-up, since it's a bit complicated.

### Changes
 - Adding infrastructure for ROS tests
 - Added safety controller executable, launch file, and code
 - Added ROS test for safety controller node

### How to test:
checked on kuri-0001c.
```
>sudo service gizmo stop
set up workspace, source devel setup.sh . . .
roslaunch mobile_base_driver kuri_drive.launch
roslaunch kuri_edu safety_controller.launch
```
Touch the bumper and observe that the robot backs up
rostopic echo /mobile_base/safety_status
Observe that safety statuses are resolved automatically