### PR TITLE
Test will notice bad node names now

### DIFF
--- a/kuri_edu/test/test_data/bad_node.launch
+++ b/kuri_edu/test/test_data/bad_node.launch
@@ -1,0 +1,11 @@
+<!--
+This launch file tries to launch a non-existent node
+-->
+
+<launch>
+
+    <node name="test_launch_file"
+          pkg="kuri_edu"
+          type="zazzlefraz"/>
+
+</launch>

--- a/kuri_edu/test/test_kuri_edu_launch.py
+++ b/kuri_edu/test/test_kuri_edu_launch.py
@@ -6,15 +6,34 @@ import os
 from nose.plugins.attrib import attr
 
 
+class NodeNotFoundException(Exception):
+    pass
+
+
 def check_launch_file(file_name):
     lf_path = roslib.packages.find_resource(
         "kuri_edu",
         file_name
     )[0]
 
+    _check_launch_file_core(lf_path)
+
+
+def _check_launch_file_core(full_path):
+    # This is split out so we can test it with test data
+    # that's not part of a ROS package
     loader = roslaunch.xmlloader.XmlLoader()
 
-    loader.load(lf_path, roslaunch.config.ROSLaunchConfig())
+    cfg = roslaunch.config.ROSLaunchConfig()
+
+    loader.load(full_path, cfg)
+
+    # Check that all the nodes are the real deal:
+    for node in cfg.nodes:
+        if not roslib.packages.find_resource(
+                   node.package,
+                   node.type):
+            raise NodeNotFoundException(node.type)
 
 
 @attr("gbz")
@@ -32,3 +51,19 @@ def test_launch_files():
         # Nose will treat this as N different tests - each for one
         # file found in the launch directory
         yield test_func, fn
+
+
+def test_bad_launch_file():
+    # This is a sanity check for ISSUE-17.  Make sure our test notices
+    # missing nodes
+    path_to_me = os.path.realpath(__file__)
+    path_to_dir = os.path.dirname(path_to_me)
+    path_to_test_data = os.path.join(path_to_dir, "test_data")
+    path_to_launch = os.path.join(path_to_test_data, "bad_node.launch")
+
+    try:
+        _check_launch_file_core(path_to_launch)
+    except NodeNotFoundException:
+        return
+
+    assert False, "_check_launch_file_core did not raise NodeNotFound"


### PR DESCRIPTION
Have launch file tests verify that nodes exist.

Add a test (that doesn't need to run in GBZ builds) that we notice missing nodes

Resolves https://github.com/MayfieldRoboticsPublic/kuri_edu/issues/17