### PR TITLE
Make sure catkin_make install works so we don't take down GBZ builds

### DIFF
--- a/ci_tools/ci.bash
+++ b/ci_tools/ci.bash
@@ -30,6 +30,8 @@ set -u
 
 echo -e "\nBuilding kuri_edu package"
 catkin_make --source .
+# Double check that we can catkin_make install
+catkin_make install --source .
 
 echo -e "\nRunning Tests"
 set +u  # Ugh. . .

--- a/ci_tools/ci.bash
+++ b/ci_tools/ci.bash
@@ -30,8 +30,6 @@ set -u
 
 echo -e "\nBuilding kuri_edu package"
 catkin_make --source .
-# Double check that we can catkin_make install
-catkin_make install --source .
 
 echo -e "\nRunning Tests"
 set +u  # Ugh. . .
@@ -39,6 +37,12 @@ source ./devel/setup.bash
 set -u
 catkin_make run_tests -j1 --source .
 catkin_test_results
+
+echo -e "\nBuilding kuri_edu install-space package"
+# Double check that we can catkin_make install.  This needs to be
+# done after tests, otherwise some of our tests will find multiple
+# kuri_edu packages
+catkin_make install --source .
 
 echo -e "\nCoverage Report:"
 # Glue together the .coverage files from different locations:

--- a/kuri_edu/CMakeLists.txt
+++ b/kuri_edu/CMakeLists.txt
@@ -8,9 +8,10 @@ catkin_python_setup()
 catkin_package()
 
 install(PROGRAMS
-  scripts/head_control
-  scripts/safety_controller
+  scripts/cap_touch_chest_light
   scripts/chest_light_controller
+  scripts/head_controller
+  scripts/safety_controller
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 


### PR DESCRIPTION
This blew up when trying to update the GBZ build.  Need catkin_make install to install stuff that's real - not typo'd stuff