### PR TITLE
Update chest_light_controller.py

### DIFF
--- a/kuri_edu/src/kuri_edu/chest_light_controller.py
+++ b/kuri_edu/src/kuri_edu/chest_light_controller.py
@@ -52,8 +52,10 @@ class ChestLedController(object):
         try:
             # self._anim will provide frames forever
             for frame in self._anim:
+                if rospy.is_shutdown():
+                    return
                 self._light_client.put_pixels(frame)
-                rate.sleep()  # This will raise an exception on shutdown
+                rate.sleep()
         except rospy.exceptions.ROSInterruptException:
             return
 


### PR DESCRIPTION
Fixed chest light controller node having to use SIGKILL on ROS shutdown.  The comment was wrong - rate.sleep() was not raising an exception when the ROS master was torn down