### PR TITLE
Update safety_controller.py

### DIFF
--- a/kuri_edu/src/kuri_edu/safety_controller.py
+++ b/kuri_edu/src/kuri_edu/safety_controller.py
@@ -134,3 +134,7 @@ class SafetyController(object):
                 angular=geometry_msgs.msg.Vector3(0, 0, 0)
             )
         )
+        # We don't have a closed-loop way of figuring out when the zero
+        # velocity has made it down to the wheels, so we'll open-loop
+        # wait here:
+        rospy.sleep(0.5)


### PR DESCRIPTION
Fix kuri surging forward because forward velocities are still queued up when we override the safety lock-out